### PR TITLE
[Endpoint-Registry ] Change relation of AASDescription with Endpoints to many:many

### DIFF
--- a/src/ts/cmd/endpoint-registry/src/services/registry/daos/entities/AASDescriptorEntity.ts
+++ b/src/ts/cmd/endpoint-registry/src/services/registry/daos/entities/AASDescriptorEntity.ts
@@ -40,7 +40,7 @@ export class AASDescriptorEntity {
   signature!: string;
 
 
-  @OneToMany(type => EndpointEntity, endpoint => endpoint.aasdescriptor, {cascade:true, eager:true})
+  @ManyToMany(type => EndpointEntity, endpoint => endpoint.aasdescriptorIds, {cascade:true, eager:true})
   @JoinTable()
   endpoints!: EndpointEntity[];
 

--- a/src/ts/cmd/endpoint-registry/src/services/registry/daos/entities/AASDescriptorEntity.ts
+++ b/src/ts/cmd/endpoint-registry/src/services/registry/daos/entities/AASDescriptorEntity.ts
@@ -40,7 +40,7 @@ export class AASDescriptorEntity {
   signature!: string;
 
 
-  @ManyToMany(type => EndpointEntity, endpoint => endpoint.aasdescriptorIds, {cascade:true, eager:true})
+  @ManyToMany(type => EndpointEntity, endpoint => endpoint.aasdescriptorIds, {cascade:true})
   @JoinTable()
   endpoints!: EndpointEntity[];
 

--- a/src/ts/cmd/endpoint-registry/src/services/registry/daos/entities/EndpointEntity.ts
+++ b/src/ts/cmd/endpoint-registry/src/services/registry/daos/entities/EndpointEntity.ts
@@ -1,4 +1,4 @@
-import {Entity, Column, PrimaryGeneratedColumn, Unique, ManyToOne, Index, PrimaryColumn, JoinTable} from "typeorm";
+import {Entity, Column, PrimaryGeneratedColumn, Unique, ManyToOne, Index, PrimaryColumn, JoinTable, ManyToMany} from "typeorm";
 import { AASDescriptorEntity } from "./AASDescriptorEntity";
 
 @Entity()
@@ -21,10 +21,10 @@ export class EndpointEntity {
       })
     target!: string;
 
-    //AASDescriptor : many Endpoints
-    @ManyToOne(type => AASDescriptorEntity, aasdescriptor => aasdescriptor.endpoints, { onUpdate: 'CASCADE', onDelete: 'CASCADE'})
+    //m AASDescriptor : n Endpoints
+    @ManyToMany(type => AASDescriptorEntity, aasdescriptor => aasdescriptor.endpoints, { onUpdate: 'CASCADE', onDelete: 'CASCADE'})
     @JoinTable()
-    aasdescriptor!: AASDescriptorEntity;
+    aasdescriptorIds!: AASDescriptorEntity[];
 
 
 }

--- a/src/ts/cmd/endpoint-registry/src/services/registry/daos/entities/EndpointEntity.ts
+++ b/src/ts/cmd/endpoint-registry/src/services/registry/daos/entities/EndpointEntity.ts
@@ -3,20 +3,19 @@ import { AASDescriptorEntity } from "./AASDescriptorEntity";
 
 @Entity()
 //the combination for address and type should also be unique (to avoid saving double)
-//@Unique("UniqueAddressAndType", ["address", "type"])
 
 export class EndpointEntity {
 
-  @PrimaryGeneratedColumn()
-  id!: string;
+  // @PrimaryColumn()
+  // id!: string;
 
-  @Column({
+  @PrimaryColumn({
     length: 1024
     })
     //TODO: validate here if this is a valid URL format
    address!: string;
 
-   @Column({
+   @PrimaryColumn({
     length: 1024
     })
     type!: string;

--- a/src/ts/cmd/endpoint-registry/src/services/registry/daos/entities/EndpointEntity.ts
+++ b/src/ts/cmd/endpoint-registry/src/services/registry/daos/entities/EndpointEntity.ts
@@ -3,15 +3,20 @@ import { AASDescriptorEntity } from "./AASDescriptorEntity";
 
 @Entity()
 //the combination for address and type should also be unique (to avoid saving double)
+//@Unique("UniqueAddressAndType", ["address", "type"])
+
 export class EndpointEntity {
 
-  @PrimaryColumn({
+  @PrimaryGeneratedColumn()
+  id!: string;
+
+  @Column({
     length: 1024
     })
     //TODO: validate here if this is a valid URL format
    address!: string;
 
-   @PrimaryColumn({
+   @Column({
     length: 1024
     })
     type!: string;
@@ -23,7 +28,6 @@ export class EndpointEntity {
 
     //m AASDescriptor : n Endpoints
     @ManyToMany(type => AASDescriptorEntity, aasdescriptor => aasdescriptor.endpoints, { onUpdate: 'CASCADE', onDelete: 'CASCADE'})
-    @JoinTable()
     aasdescriptorIds!: AASDescriptorEntity[];
 
 

--- a/src/ts/cmd/endpoint-registry/src/services/registry/daos/postgres/Registry.ts
+++ b/src/ts/cmd/endpoint-registry/src/services/registry/daos/postgres/Registry.ts
@@ -93,7 +93,6 @@ class Registry implements iRegistry {
     try {
 
       let aasDescriptorRepository = this.client.getRepository(AASDescriptorEntity);
-      let assetssRepository = this.client.getRepository(AssetEntity);
       let endpointsRepository = this.client.getRepository(EndpointEntity);
 
       //check if the AASDescriptor is already registered in DB

--- a/src/ts/cmd/endpoint-registry/src/services/registry/daos/postgres/RegistryFactory.ts
+++ b/src/ts/cmd/endpoint-registry/src/services/registry/daos/postgres/RegistryFactory.ts
@@ -11,10 +11,9 @@ class RegistryFactory {
       let client = getConnection();
       return new Registry(client);
     } catch (error) {
-      logger.error(
+      logger.info(
         'No database Connection could be established, will try reconnecting'
       );
-      logger.error('Error:' + error)
       try{
         let client =  await this.createDBConnection();
         return new Registry(getConnection());

--- a/src/ts/cmd/endpoint-registry/test/integration/CustomAPIRegistry.spec.ts
+++ b/src/ts/cmd/endpoint-registry/test/integration/CustomAPIRegistry.spec.ts
@@ -26,7 +26,7 @@ function replaceRoleNameInFirstRole(
   protocol.roles[0].name = replacement;
   return protocol;
 }
-function makeGoodSemanticProtocol(idTag: string) {
+function makeGoodSemanticProtocolWithOneRole(idTag: string) {
   return <ISemanticProtocol>{
     identification: {
       id: 'semanticProtocolId' + idTag,
@@ -60,7 +60,7 @@ function makeSemanticProtocolWithDifferentAAS(idTag: string) {
     ]
   };
 }
-function makeGoodSemanticProtocolWith2Roles(semProtId:string, idTag1: string, idTag2: string) {
+function makeGoodSemanticProtocolWith2Roles(semProtId: string, idTag1: string, idTag2: string) {
   return <ISemanticProtocol>{
     identification: {
       id: 'semanticProtocolId' + semProtId,
@@ -165,7 +165,7 @@ describe('Tests with a simple data model', function () {
           await requester
             .put('/SemanticProtocols')
             .auth(user, password)
-            .send(makeGoodSemanticProtocol(uniqueTestId))
+            .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
             .then(async (res: any) => {
               chai.expect(res.status).to.eql(200);
 
@@ -173,7 +173,7 @@ describe('Tests with a simple data model', function () {
               await requester
                 .put('/SemanticProtocols')
                 .auth(user, password)
-                .send(makeGoodSemanticProtocol(uniqueTestId))
+                .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
                 .then(async (res: any) => {
                   chai.expect(res.status).to.eql(422);
                 });
@@ -199,7 +199,7 @@ describe('Tests with a simple data model', function () {
         await requester
           .put('/SemanticProtocols')
           .auth(user, password)
-          .send(makeGoodSemanticProtocol(uniqueTestId))
+          .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
           .then(async (res: any) => {
             chai.expect(res.status).to.eql(200);
             await requester
@@ -233,7 +233,7 @@ describe('Tests with a simple data model', function () {
       .request(app)
       .put('/SemanticProtocols')
       .auth(user, 'blah')
-      .send(makeGoodSemanticProtocol(uniqueTestId))
+      .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
       .then(async (res: any) => {
         chai.expect(res.status).to.eql(401);
       });
@@ -259,7 +259,7 @@ describe('Tests with a simple data model', function () {
           await requester
             .put('/SemanticProtocols')
             .auth(user, password)
-            .send(makeGoodSemanticProtocol(uniqueTestId))
+            .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
             .then(async (res: any) => {
               chai.expect(res.status).to.eql(200);
               //finally try retrieving the semantic protocol from the database
@@ -301,7 +301,7 @@ describe('Tests with a simple data model', function () {
           await requester
             .put('/SemanticProtocols')
             .auth(user, password)
-            .send(makeGoodSemanticProtocol(uniqueTestId))
+            .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
             .then(async (res: any) => {
               chai.expect(res.status).to.eql(200);
               //finally try retrieving the semantic protocol from the database
@@ -337,7 +337,7 @@ describe('Tests with a simple data model', function () {
         await requester
           .put('/SemanticProtocols')
           .auth(user, password)
-          .send(makeGoodSemanticProtocol(uniqueTestId))
+          .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
           .then(async (res: any) => {
             chai.expect(res.status).to.eql(200);
             let numProtFound = await getConnection().manager.find(SemanticProtocolEntity, { id: 'semanticProtocolId' + uniqueTestId })
@@ -389,7 +389,7 @@ describe('Tests with a simple data model', function () {
           await requester
             .put('/SemanticProtocols')
             .auth(user, password)
-            .send(makeGoodSemanticProtocol(uniqueTestId))
+            .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
             .then(async (res: any) => {
               chai.expect(res.status).to.eql(200);
               let numProtFound = await getConnection().manager.find(SemanticProtocolEntity, { id: 'semanticProtocolId' + uniqueTestId })
@@ -417,7 +417,7 @@ describe('Tests with a simple data model', function () {
                   await requester
                     .put('/SemanticProtocols')
                     .auth(user, password)
-                    .send(makeGoodSemanticProtocol(uniqueTestId))
+                    .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
                     .then(async (res: any) => {
                       chai.expect(res.status).to.eql(200);
                     });
@@ -464,7 +464,7 @@ describe('Tests with a simple data model', function () {
         await requester
           .put('/SemanticProtocols')
           .auth(user, password)
-          .send(makeGoodSemanticProtocol(uniqueTestId))
+          .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
           .then(async (res: any) => {
             chai.expect(res.status).to.eql(200);
 
@@ -472,7 +472,7 @@ describe('Tests with a simple data model', function () {
             await requester
               .patch('/SemanticProtocols/semanticProtocolId' + uniqueTestId)
               .auth(user, password)
-              .send(replaceRoleNameInFirstRole(makeGoodSemanticProtocol(uniqueTestId), 'newRoleA' + uniqueTestId))
+              .send(replaceRoleNameInFirstRole(makeGoodSemanticProtocolWithOneRole(uniqueTestId), 'newRoleA' + uniqueTestId))
               .then(async (res: any) => {
                 chai.expect(res.status).to.eql(200);
                 //load the roles for this semanticprotocol
@@ -483,7 +483,7 @@ describe('Tests with a simple data model', function () {
                   .where("role.semProtocol = :semProtocol", { semProtocol: 'semanticProtocolId' + uniqueTestId })
                   .execute();
                 //the number of roles should remain the same after the patch
-                chai.expect(rolesForProtFound.length).to.eql(makeGoodSemanticProtocol(uniqueTestId).roles.length);
+                chai.expect(rolesForProtFound.length).to.eql(makeGoodSemanticProtocolWithOneRole(uniqueTestId).roles.length);
                 console.log("rolesfound " + JSON.stringify(rolesForProtFound))
                 chai.expect(
                   _.some(rolesForProtFound, {
@@ -509,7 +509,7 @@ describe('Tests with a simple data model', function () {
         .patch('/SemanticProtocols/semanticProtocolId' + uniqueTestId)
         .auth(user, password)
         .send(
-          makeGoodSemanticProtocol(differentUniqueTestId)
+          makeGoodSemanticProtocolWithOneRole(differentUniqueTestId)
         )
         .then(async (res: any) => {
           chai.expect(res.status).to.eql(422);
@@ -530,7 +530,7 @@ describe('Tests with a simple data model', function () {
       .patch('/SemanticProtocols/semanticProtocolId' + uniqueTestId)
       .auth(user, password)
       .send(
-        makeGoodSemanticProtocol(uniqueTestId)
+        makeGoodSemanticProtocolWithOneRole(uniqueTestId)
       )
       .then(async (res: any) => {
         chai.expect(res.status).to.eql(422);
@@ -647,38 +647,38 @@ describe('Tests with a simple data model', function () {
     var uniqueTestId = 'simpleDataTest' + getRandomInteger();
     var requester = chai.request(app).keepOpen();
 
- //first register an AAS
- await requester
- .put('/AASDescriptors')
- .auth(user, password)
- .send(makeGoodAASDescriptor(uniqueTestId))
- .then(async (res: any) => {
-   chai.expect(res.status).to.eql(200);
+    //first register an AAS
+    await requester
+      .put('/AASDescriptors')
+      .auth(user, password)
+      .send(makeGoodAASDescriptor(uniqueTestId))
+      .then(async (res: any) => {
+        chai.expect(res.status).to.eql(200);
 
-   //then register a SemanticProtocol
-   await requester
-     .put('/SemanticProtocols')
-     .auth(user, password)
-     .send(makeGoodSemanticProtocol(uniqueTestId))
-     .then(async (res: any) => {
-       chai.expect(res.status).to.eql(200);
-       let numProtFound = await getConnection().manager.find(SemanticProtocolEntity, { id: 'semanticProtocolId' + uniqueTestId })
-       //console.log("Protocols found "+ JSON.stringify(numProtFound));
-       chai.expect(numProtFound.length).to.be.eql(1);
+        //then register a SemanticProtocol
+        await requester
+          .put('/SemanticProtocols')
+          .auth(user, password)
+          .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
+          .then(async (res: any) => {
+            chai.expect(res.status).to.eql(200);
+            let numProtFound = await getConnection().manager.find(SemanticProtocolEntity, { id: 'semanticProtocolId' + uniqueTestId })
+            //console.log("Protocols found "+ JSON.stringify(numProtFound));
+            chai.expect(numProtFound.length).to.be.eql(1);
 
-        //then try registering the same SemanticProtocol, it should update it
-   await requester
-   .put('/admin/SemanticProtocols')
-   .auth(user, password)
-   .send(makeGoodSemanticProtocol(uniqueTestId))
-   .then(async (res: any) => {
-     chai.expect(res.status).to.eql(200);
-     let numProtFound = await getConnection().manager.find(SemanticProtocolEntity, { id: 'semanticProtocolId' + uniqueTestId })
-     //console.log("Protocols found "+ JSON.stringify(numProtFound));
-     chai.expect(numProtFound.length).to.be.eql(1);
-  });
-  });
-  });
+            //then try registering the same SemanticProtocol, it should update it
+            await requester
+              .put('/admin/SemanticProtocols')
+              .auth(user, password)
+              .send(makeGoodSemanticProtocolWithOneRole(uniqueTestId))
+              .then(async (res: any) => {
+                chai.expect(res.status).to.eql(200);
+                let numProtFound = await getConnection().manager.find(SemanticProtocolEntity, { id: 'semanticProtocolId' + uniqueTestId })
+                //console.log("Protocols found "+ JSON.stringify(numProtFound));
+                chai.expect(numProtFound.length).to.be.eql(1);
+              });
+          });
+      });
   });
 
 
@@ -710,7 +710,7 @@ describe('Tests with a simple data model', function () {
           .then(async (res: any) => {
 
             //the SemanticProtocol to be registered
-            var semProtocolRequest = makeGoodSemanticProtocolWith2Roles(semProtocolTestId,firstTestId, secondTestId)
+            var semProtocolRequest = makeGoodSemanticProtocolWith2Roles(semProtocolTestId, firstTestId, secondTestId)
             //then register a SemanticProtocol
             await requester
               .put('/SemanticProtocols')
@@ -725,7 +725,7 @@ describe('Tests with a simple data model', function () {
                   .auth(user, password)
                   .then((response: any) => {
                     chai.expect(response.status).to.eql(200);
-                     console.log("first read response is " + JSON.stringify(response.body) + " first AASID was "+JSON.stringify(aasRequest_1.identification))
+                    console.log("first read response is " + JSON.stringify(response.body) + " first AASID was " + JSON.stringify(aasRequest_1.identification))
                     //check if role registered correctly
 
                     chai.expect(
@@ -741,7 +741,7 @@ describe('Tests with a simple data model', function () {
                   .auth(user, password)
                   .then((response: any) => {
                     chai.expect(response.status).to.eql(200);
-                    console.log("second read response is " + JSON.stringify(response.body) + " second AASID was "+JSON.stringify(aasRequest_2.identification))
+                    console.log("second read response is " + JSON.stringify(response.body) + " second AASID was " + JSON.stringify(aasRequest_2.identification))
                     //check if role registered correctly
                     chai.expect(
                       _.some(response.body, {
@@ -758,85 +758,85 @@ describe('Tests with a simple data model', function () {
 
 
 
-  it("should throw a 422 if role does not exist when trying to retrieve"+
-  " all AASDescriptors by semanticProtocol and role", async function () {
-    var randTestId = 'randId-' + getRandomInteger();
-    var requester = chai.request(app).keepOpen();
+  it("should throw a 422 if role does not exist when trying to retrieve" +
+    " all AASDescriptors by semanticProtocol and role", async function () {
+      var randTestId = 'randId-' + getRandomInteger();
+      var requester = chai.request(app).keepOpen();
 
-    //first register an AAS
-    var aasRequest_1 = makeGoodAASDescriptor(randTestId)
+      //first register an AAS
+      var aasRequest_1 = makeGoodAASDescriptor(randTestId)
 
-    await requester
-      .put('/AASDescriptors')
-      .auth(user, password)
-      .send(aasRequest_1)
-      .then(async (res: any) => {
-        chai.expect(res.status).to.eql(200);
+      await requester
+        .put('/AASDescriptors')
+        .auth(user, password)
+        .send(aasRequest_1)
+        .then(async (res: any) => {
+          chai.expect(res.status).to.eql(200);
 
-            //the SemanticProtocol to be registered
-            var semProtocolRequest = makeGoodSemanticProtocol(randTestId)
-            //then register a SemanticProtocol
-            await requester
-              .put('/SemanticProtocols')
-              .auth(user, password)
-              .send(semProtocolRequest)
-              .then(async (res: any) => {
-                chai.expect(res.status).to.eql(200);
-                //finally try retrieving the list of AASs based on the semanticprotocol and rolename
-                //read the AASDescriptor for the first role
-                await requester
-                  .get('/SemanticProtocols/semanticProtocolId' + randTestId + '/role/' + "fooBarRole" + '/AASDescriptors')
-                  .auth(user, password)
-                  .then((response: any) => {
-                    chai.expect(response.status).to.eql(422);
-                  });
-              })
-              .then(() => {
-                requester.close();
-              });
-      });
-  });
-  it("should return an empty array if no AASDescriptor exists for the given role when trying to retrieve"+
-  " all AASDescriptors by semanticProtocol and role", async function () {
-    var randTestId = 'randId-' + getRandomInteger();
-    var requester = chai.request(app).keepOpen();
+          //the SemanticProtocol to be registered
+          var semProtocolRequest = makeGoodSemanticProtocolWithOneRole(randTestId)
+          //then register a SemanticProtocol
+          await requester
+            .put('/SemanticProtocols')
+            .auth(user, password)
+            .send(semProtocolRequest)
+            .then(async (res: any) => {
+              chai.expect(res.status).to.eql(200);
+              //finally try retrieving the list of AASs based on the semanticprotocol and rolename
+              //read the AASDescriptor for the first role
+              await requester
+                .get('/SemanticProtocols/semanticProtocolId' + randTestId + '/role/' + "fooBarRole" + '/AASDescriptors')
+                .auth(user, password)
+                .then((response: any) => {
+                  chai.expect(response.status).to.eql(422);
+                });
+            })
+            .then(() => {
+              requester.close();
+            });
+        });
+    });
+  it("should return an empty array if no AASDescriptor exists for the given role when trying to retrieve" +
+    " all AASDescriptors by semanticProtocol and role", async function () {
+      var randTestId = 'randId-' + getRandomInteger();
+      var requester = chai.request(app).keepOpen();
 
-    //first register an AAS
-    var aasRequest_1 = makeGoodAASDescriptor(randTestId)
+      //first register an AAS
+      var aasRequest_1 = makeGoodAASDescriptor(randTestId)
 
-    await requester
-      .put('/AASDescriptors')
-      .auth(user, password)
-      .send(aasRequest_1)
-      .then(async (res: any) => {
-        chai.expect(res.status).to.eql(200);
+      await requester
+        .put('/AASDescriptors')
+        .auth(user, password)
+        .send(aasRequest_1)
+        .then(async (res: any) => {
+          chai.expect(res.status).to.eql(200);
 
-            //the SemanticProtocol to be registered
-            var semProtocolRequest = makeSemanticProtocolWithDifferentAAS(randTestId)
-            //then register a SemanticProtocol
-            await requester
-              .put('/SemanticProtocols')
-              .auth(user, password)
-              .send(semProtocolRequest)
-              .then(async (res: any) => {
-                chai.expect(res.status).to.eql(200);
-                //finally try retrieving the list of AASs based on the semanticprotocol and rolename
-                //read the AASDescriptor for the first role
-                await requester
-                  .get('/SemanticProtocols/semanticProtocolId' + randTestId + '/role/' + semProtocolRequest.roles[0].name + '/AASDescriptors')
-                  .auth(user, password)
-                  .then((response: any) => {
-                    chai.expect(response.status).to.eql(200);
+          //the SemanticProtocol to be registered
+          var semProtocolRequest = makeSemanticProtocolWithDifferentAAS(randTestId)
+          //then register a SemanticProtocol
+          await requester
+            .put('/SemanticProtocols')
+            .auth(user, password)
+            .send(semProtocolRequest)
+            .then(async (res: any) => {
+              chai.expect(res.status).to.eql(200);
+              //finally try retrieving the list of AASs based on the semanticprotocol and rolename
+              //read the AASDescriptor for the first role
+              await requester
+                .get('/SemanticProtocols/semanticProtocolId' + randTestId + '/role/' + semProtocolRequest.roles[0].name + '/AASDescriptors')
+                .auth(user, password)
+                .then((response: any) => {
+                  chai.expect(response.status).to.eql(200);
 
-                    chai.expect(
-                      response.body).to.be.eql([]);
-                  });
-              })
-              .then(() => {
-                requester.close();
-              });
-      });
-  });
+                  chai.expect(
+                    response.body).to.be.eql([]);
+                });
+            })
+            .then(() => {
+              requester.close();
+            });
+        });
+    });
 
 
 
@@ -864,7 +864,7 @@ describe('Tests with a simple data model', function () {
           .then(async (res: any) => {
             chai.expect(res.status).to.eql(200);
             //the SemanticProtocol to be registered
-            var semProtocolRequest = makeGoodSemanticProtocol(uniqueTestId)
+            var semProtocolRequest = makeGoodSemanticProtocolWithOneRole(uniqueTestId)
             //then register a SemanticProtocol
             await requester
               .put('/SemanticProtocols')
@@ -926,7 +926,7 @@ describe('Tests with a simple data model', function () {
           .then(async (res: any) => {
             chai.expect(res.status).to.eql(200);
             //the SemanticProtocol to be registered
-            var semProtocolRequest = addAASIDtoFirstRoleofSemanticProtocol(makeGoodSemanticProtocol(uniqueTestId), extraAASRequest.identification)
+            var semProtocolRequest = addAASIDtoFirstRoleofSemanticProtocol(makeGoodSemanticProtocolWithOneRole(uniqueTestId), extraAASRequest.identification)
             //then register a SemanticProtocol
             await requester
               .put('/SemanticProtocols')
@@ -974,15 +974,21 @@ describe('Tests with a simple data model', function () {
       });
   });
 /*
-  it('leaves other AASDescriptor Identifier of a role unchanged when deleting one from a role', async function () {
-    var uniqueTestId = 'randId-' + getRandomInteger();
-    var newUniqueTestId = 'extra-' + getRandomInteger();
+  it('do not alter or remove a role already related to multiple AASDescriptors when updating a semantic protodol', async function () {
+    var uniqueTestId = 'simpleDataTest' + getRandomInteger();
+    var newUniqueTestId = 'newsimpleDataTest' + getRandomInteger();
     var requester = chai.request(app).keepOpen();
 
     //first register an AAS
     var aasRequest = makeGoodAASDescriptor(uniqueTestId)
-    var extraAASRequest = makeGoodAASDescriptor(newUniqueTestId)
-    var semProtocolRequestWithOneAAS = makeGoodSemanticProtocol(uniqueTestId)
+    var secondAASRequest = makeGoodAASDescriptor(newUniqueTestId)
+    var semProtocolRequestWithOneAAS = makeGoodSemanticProtocolWithOneRole(uniqueTestId)
+    var secondSemProtocolRequestWithOneAAS = makeGoodSemanticProtocolWithOneRole(newUniqueTestId)
+
+    // change the role of the second semProtocol to have the same AAS to the first one
+    var secondSemProtocolRequest = addAASIDtoFirstRoleofSemanticProtocol(secondSemProtocolRequestWithOneAAS, aasRequest.identification)
+
+    //register an AASDescriptor
     await requester
       .put('/AASDescriptors')
       .auth(user, password)
@@ -993,43 +999,61 @@ describe('Tests with a simple data model', function () {
         await requester
           .put('/AASDescriptors')
           .auth(user, password)
-          .send(extraAASRequest)
+          .send(secondAASRequest)
+          //register a semantic protocol with a role
           .then(async (res: any) => {
             chai.expect(res.status).to.eql(200);
-            //the SemanticProtocol to be registered
-            var semProtocolRequest = addAASIDtoFirstRoleofSemanticProtocol(semProtocolRequestWithOneAAS, extraAASRequest.identification)
-            //then register a SemanticProtocol
+            //then register a SemanticProtocol with the first AAS associated to a role
             await requester
               .put('/SemanticProtocols')
               .auth(user, password)
-              .send(semProtocolRequest)
+              .send(semProtocolRequestWithOneAAS)
               .then(async (res: any) => {
                 chai.expect(res.status).to.eql(200);
                 //check if AAS was assigned correctly to the role
                 let loadedRole = await getConnection().getRepository(RoleEntity).findOne({
                   where: [
-                    { semProtocol: 'semanticProtocolId' + uniqueTestId }, { name: semProtocolRequest.roles[0].name }],
+                    { semProtocol: 'semanticProtocolId' + uniqueTestId }, { name: semProtocolRequestWithOneAAS.roles[0].name }],
                   relations: ["aasDescriptorIds"]
                 })
 
-                console.log("Registered role AASs "+ JSON.stringify(loadedRole?.aasDescriptorIds))
+                //The role should be assigned now to AASDescriptors
+                console.log("Registered role AASs " + JSON.stringify(loadedRole?.aasDescriptorIds))
                 chai.expect(
                   _.some(loadedRole?.aasDescriptorIds, {
-                    id: extraAASRequest.identification.id
+                    id: semProtocolRequestWithOneAAS.roles[0].aasDescriptorIds[0].id
                   })).to.be.true;
 
-                //finally try un-assigning am AASId from the role
+                  //now register a second semantic protocol with a role that has the same AAS with the previous
                 await requester
-                  .delete('/SemanticProtocols/semanticProtocolId' + uniqueTestId + '/role/'
-                    + semProtocolRequest.roles[0].name + '/AASDescriptors/' + extraAASRequest.identification.id)
+                  .put('/SemanticProtocols')
                   .auth(user, password)
-                  .then(async (response: any) => {
+                  .send(secondSemProtocolRequest)
+                  chai.expect(res.status).to.eql(200);
+
+                  let loadedRole2 = await getConnection().getRepository(RoleEntity).findOne({
+                    where: [
+                      { semProtocol: 'semanticProtocolId' + newUniqueTestId }, { name: secondSemProtocolRequest.roles[0].name }],
+                    relations: ["aasDescriptorIds"]
+                  })
+                  //see if this role has indeed this AAS
+                  chai.expect(
+                    _.some(loadedRole2?.aasDescriptorIds, {
+                      id: secondSemProtocolRequest.roles[0].aasDescriptorIds[0].id
+                    })).to.be.true;
+
+                //finally try un-assigning am AASId from the role
+                 await requester
+                   .delete('/SemanticProtocols/semanticProtocolId' + uniqueTestId + '/role/'
+                     + semProtocolRequestWithOneAAS.roles[0].name + '/AASDescriptors/' + semProtocolRequestWithOneAAS.identification.id)
+                   .auth(user, password)
+                   .then(async (response: any) => {
                     chai.expect(response.status).to.eql(200);
                     //  console.log("body is " + JSON.stringify(response.body))
                     //check if AAS Assignment was correctly removed from  the role
                     let loadedRole = await getConnection().getRepository(RoleEntity).findOne({
                       where: [
-                        { semProtocol: 'semanticProtocolId' + uniqueTestId }, { name: semProtocolRequest.roles[0].name }],
+                        { semProtocol: 'semanticProtocolId' + uniqueTestId }, { name: semProtocolRequestWithOneAAS.roles[0].name }],
                       relations: ["aasDescriptorIds"]
                     })
                     console.log("AAS IDs " + JSON.stringify(loadedRole?.aasDescriptorIds))
@@ -1037,7 +1061,7 @@ describe('Tests with a simple data model', function () {
                     //check if the new AAS was assigned to the role
                     chai.expect(
                       _.some(loadedRole?.aasDescriptorIds, {
-                        id: extraAASRequest.identification.id
+                        id: secondSemProtocolRequest.identification.id
                       })).to.be.false;
                       //check that the original role AAS Assignment still exists
                     chai.expect(
@@ -1046,6 +1070,8 @@ describe('Tests with a simple data model', function () {
                       })).to.be.true;
 
                   });
+              })
+              .then(async (res: any) => {
               })
               .then(() => {
                 requester.close();


### PR DESCRIPTION
In order to facilitate the use-case that the same Endpoint can accommodate multiple AASs the relation to the Endpoint-Registry is changed to m:n
- Tests were updated