### PR TITLE
Endpoint reg get by role fix

### DIFF
--- a/src/ts/cmd/endpoint-registry/src/services/registry/daos/postgres/Registry.ts
+++ b/src/ts/cmd/endpoint-registry/src/services/registry/daos/postgres/Registry.ts
@@ -471,7 +471,8 @@ class Registry implements iRegistry {
       let aasIds = loadedRole.aasDescriptorIds.map(identifier => identifier.id)
 
       //load the AASDescriptorEntities from the Database
-      let AASDescriptorEntitiesArray = await aasDescriptorRepository.find({ id: In(aasIds) });
+      let AASDescriptorEntitiesArray = await aasDescriptorRepository
+      .find({where: [{ id: In(aasIds)}], relations: ["endpoints", "asset"]});
 
       //For each entity we need to construct a IAASDescriptor Object
       if (AASDescriptorEntitiesArray) {

--- a/src/ts/cmd/endpoint-registry/test/integration/CustomAPIRegistry.spec.ts
+++ b/src/ts/cmd/endpoint-registry/test/integration/CustomAPIRegistry.spec.ts
@@ -732,6 +732,14 @@ describe('Tests with a simple data model', function () {
                       _.some(response.body, {
                         identification: aasRequest_1.identification
                       })).to.be.true;
+
+
+                      //check if the endpoints are also there
+                      chai.expect(
+                        _.some(response.body[0].descriptor?.endpoints, {
+                          address: aasRequest_1.descriptor.endpoints[0].address
+                        })).to.be.true;
+
                   });
               })
               .then(async (res: any) => {
@@ -747,6 +755,14 @@ describe('Tests with a simple data model', function () {
                       _.some(response.body, {
                         identification: aasRequest_2.identification
                       })).to.be.true;
+
+
+                      //check if the endpoints are also there
+                      chai.expect(
+                        _.some(response.body[0].descriptor?.endpoints, {
+                          address: aasRequest_2.descriptor.endpoints[0].address
+                        })).to.be.true;
+
                   });
               })
               .then(() => {


### PR DESCRIPTION
After the last changes to Endpoint and AASDescriptor relation type, the Endpoints were not loaded eagerly with AASDescriptorEntities. That led to not being returned with the READ AASDescriptors by semanticprotocol and role Call.

This was fixed and the tests were updated for this call to check the endpoints being correctly returned