### PR TITLE
Fix adapter registry persistence

### DIFF
--- a/helm/i40-aas/templates/adapter-registry.yaml
+++ b/helm/i40-aas/templates/adapter-registry.yaml
@@ -88,7 +88,7 @@ spec:
           initialDelaySeconds: 600
           periodSeconds: 60
         volumeMounts:
-        - mountPath: /service/.node-persist
+        - mountPath: "/etc/nodepersist"
           name: {{ .Release.Name }}-adapter-registry
         {{- if .Values.security.certificates }}
         - name: certs

--- a/helm/i40-aas/templates/adapter-registry.yaml
+++ b/helm/i40-aas/templates/adapter-registry.yaml
@@ -74,8 +74,8 @@ spec:
         envFrom:
         - secretRef:
             name: {{ .Release.Name }}-core-registries-adapters
-        resources:
-          {{- toYaml .Values.resources.ts | nindent 10 }}
+#        resources:
+#          {{- toYaml .Values.resources.ts | nindent 10 }}
         livenessProbe:
           httpGet:
             path: /health

--- a/src/ts/cmd/adapter-registry/src/services/registry/RegistryFactory.ts
+++ b/src/ts/cmd/adapter-registry/src/services/registry/RegistryFactory.ts
@@ -6,7 +6,7 @@ class RegistryFactory {
   static async getRegistryLocal(): Promise<Registry> {
     var storage = require('node-persist');
 
-    await storage.init(/* options ... */);
+    await storage.init({dir: '../../etc/nodepersist/data', forgiveParseErrors: true, logging: true});
     logger.debug('Local storage initialized ');
 
     return new Registry(storage);


### PR DESCRIPTION
The mount path of the persistent volume wasn't up to date with our file structure in the container. Thus, the data was not persisted properly across container restarts. 
Also, now we explicitly set a path for the local storage of the node-persist module. 

Additionally, since we observe mysterious restarts of the adapter-registry containers on kubernetes deployments we removed the resource limits to exclude this as a possible cause. 