### PR TITLE
Bump npm from 6.13.7 to 6.14.6 in /src/node-red/echo-skill

### DIFF
--- a/src/node-red/echo-skill/package.json
+++ b/src/node-red/echo-skill/package.json
@@ -11,7 +11,7 @@
     "i40-aas-nodes": "file:customNodes",
     "node-red": "1.0.3",
     "node-red-contrib-amqp": "1.0.2",
-    "npm": "~6.13.7"
+    "npm": ">=6.14.6"
   },
   "engines": {
     "node": ">=10"


### PR DESCRIPTION
Remediation of https://github.com/SAP/i40-aas/network/alert/src/node-red/echo-skill/package.json/npm/open 
