### PR TITLE
Fix: Endpoint-resolver cannot recreate connection

### DIFF
--- a/src/go/cmd/endpoint-resolver/endpointresolver.go
+++ b/src/go/cmd/endpoint-resolver/endpointresolver.go
@@ -122,9 +122,10 @@ func (r *EndpointResolver) processDelivery(d amqp.Delivery) {
 	if err != nil {
 		log.Error().Err(err).Msgf("failed to process %dB delivery [%v]", len(d.Body), d.DeliveryTag)
 		d.Nack(false, false)
-	}
-	log.Debug().Msgf("processed %dB delivery [%v]: ACK", len(d.Body), d.DeliveryTag)
-	d.Ack(false)
+	} else {
+    log.Debug().Msgf("processed %dB delivery [%v]: ACK", len(d.Body), d.DeliveryTag)
+    d.Ack(false)
+  }
 }
 
 func (r *EndpointResolver) processGenericEgressMsg(d amqp.Delivery) error {


### PR DESCRIPTION
Fixed a bug where a client tried to acknowledge a message after rejecting it, causing a channel exception which made the client unable to further consume this channel, sending the client into an endless loop of "declaring Queue" and "failed on Queue Declare". 